### PR TITLE
Add collada-dom dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: openhrp
 Section: science
 Priority: extra
 Maintainer: Fumio KANEHIRO <f-kanehiro@aist.go.jp>
-Build-Depends: debhelper (>= 7.5), cmake(>= 2.4.0), pkg-config (>= 0.22), openrtm-aist (>= 1.0.0), openrtm-aist-dev (>= 1.0.0), jython (>= 2.2.0), libboost-all-dev (>= 1.40.0), liblapack-dev (>= 3.2.1), libeigen3-dev (>= 3.0.1), libjpeg-dev, libpng-dev, openjdk-6-jdk | openjdk-8-jdk, doxygen (>=1.6.3), graphviz, libxml2-dev (>= 2.7.6), libf2c2-dev, libgl1-mesa-dev, libxext-dev, libomniorb4-dev, omniidl, omniorb-idl, omniidl-python, python-omniorb, uuid-dev
+Build-Depends: debhelper (>= 7.5), cmake(>= 2.4.0), pkg-config (>= 0.22), openrtm-aist (>= 1.0.0), openrtm-aist-dev (>= 1.0.0), jython (>= 2.2.0), libboost-all-dev (>= 1.40.0), liblapack-dev (>= 3.2.1), libeigen3-dev (>= 3.0.1), libjpeg-dev, libpng-dev, openjdk-6-jdk | openjdk-8-jdk, doxygen (>=1.6.3), graphviz, libxml2-dev (>= 2.7.6), libf2c2-dev, libgl1-mesa-dev, libxext-dev, libomniorb4-dev, omniidl, omniorb-idl, omniidl-python, python-omniorb, uuid-dev, libcollada-dom2.4-dp-dev
 Standards-Version: 3.9.2
 Homepage: http://www.openrtp.jp/openhrp3/en/index.html
 #Vcs-Git: git://git.debian.org/collab-maint/openhrp3.git


### PR DESCRIPTION
This PR adds `libcollada-dom2.4-dp-dev` to the list of dependencies. This enables openhrp to build with collada support, and adds the corresponding binary tools, such as `openhrp-export-collada` that I use to automatically convert some of the robot models from VRML.